### PR TITLE
Added Travis setup (fixes #1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+os:
+  - linux
+python: 3.5
+install:
+  - python setup.py install --user
+
+script:
+  - python -m pytest

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,21 @@
 import setuptools
 
-with open('README.md', 'r') as f:
+with open("README.md", "r") as f:
     my_long_description = f.read()
+
+
+documentation_packages = []
+regular_packages = [
+    "click",
+    "mlflow",
+    "pandas",
+    "pillow",
+    "tensorflow",
+    "tensorflow_hub"
+]
+testing_packages = [
+    "pytest"
+]
 
 setuptools.setup(
     name="autofocus",
@@ -15,6 +29,10 @@ setuptools.setup(
     long_description=my_long_description,
 
     packages=setuptools.find_packages(),
+    test_suite="tests",
 
-    install_requires=['click', 'mlflow', 'pandas', 'pillow', 'tensorflow', 'tensorflow_hub']
+    install_requires=regular_packages,
+    extras_require={
+        "testing": testing_packages + regular_packages
+    }
 )


### PR DESCRIPTION
In this PR, I attempted to add a basic Travis CI setup. This will build your package + run the tests on:

* every commit on an open PR
* every merge to `master`

I had to make a slight modification to `setup.py`, declaring the testing packages needed.

Let's see if it builds, and if it does I'll add more Python versions and mac OS to this PR.