### PR TITLE
Added check for Datetime in exif of images

### DIFF
--- a/autofocus/preprocess_images.py
+++ b/autofocus/preprocess_images.py
@@ -136,8 +136,11 @@ def get_timestamp(exif: dict) -> datetime:
     Args:
         exif: dictionary of Exif metadata that includes "DateTime"
     """
-    timestamp = exif['DateTime']
-    timestamp = datetime.strptime(timestamp, '%Y:%m:%d %H:%M:%S')
+    if 'DateTime' in exif:
+        timestamp = exif['DateTime']
+        timestamp = datetime.strptime(timestamp, '%Y:%m:%d %H:%M:%S')
+    else:
+        timestamp = None
     return timestamp
 
 


### PR DESCRIPTION
In certain new incoming images, the Date time value wast not present in exif, leading to key error. Hence an additional check is added to ensure pre processing runs even in the absence of date time